### PR TITLE
Compound documents documentation fix

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -171,7 +171,7 @@ Now you can include some data in a dump by specifying the includes.
 
 .. code-block:: python
 
-    ArticleSchema(include=('comments',)).dump(article).data
+    ArticleSchema(include_data=('comments',)).dump(article).data
     # {
     #     "data": {
     #         "id": 1,


### PR DESCRIPTION
Per @v-ken's comment, this commit fixes a small error in the documentation of
the compound documents (i.e. `included`) feature in
PR marshmallow-code/marshmallow-jsonapi#40

https://github.com/marshmallow-code/marshmallow-jsonapi/pull/40#issuecomment-225129348
