### PR TITLE
Compound documents, support for many "self" for include_data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ _sandbox
 # Virtual Environment
 env
 venv
+.python-version

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -171,7 +171,7 @@ Now you can include some data in a dump by specifying the includes.
 
 .. code-block:: python
 
-    ArticleSchema(include=('comments',)).dump(article).data
+    ArticleSchema(include_data=('comments',)).dump(article).data
     # {
     #     "data": {
     #         "id": 1,

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -96,18 +96,21 @@ class Relationship(BaseRelationship):
     @property
     def schema(self):
         if isinstance(self.__schema, SchemaABC):
-            return self.__schema
-        if isinstance(self.__schema, type) and issubclass(self.__schema, SchemaABC):
-            self.__schema = self.__schema()
-            return self.__schema
-        if isinstance(self.__schema, basestring):
+            pass
+        elif isinstance(self.__schema, type) and issubclass(self.__schema, SchemaABC):
+            self.__schema = self.__schema(many=self.many)
+        elif isinstance(self.__schema, basestring):
             if self.__schema == _RECURSIVE_NESTED:
                 parent_class = self.parent.__class__
-                self.__schema = parent_class(many=self.many)
+                self.__schema = parent_class(
+                    include_data=self.parent.include_data)
             else:
                 schema_class = class_registry.get_class(self.__schema)
                 self.__schema = schema_class()
-            return self.__schema
+        else:
+            raise ValueError(('A Schema is required to serialize a nested '
+                              'relationship with include_data'))
+        return self.__schema
 
     def get_related_url(self, obj):
         if self.related_url:

--- a/marshmallow_jsonapi/schema.py
+++ b/marshmallow_jsonapi/schema.py
@@ -83,8 +83,6 @@ class Schema(ma.Schema):
                 if not isinstance(field, BaseRelationship):
                     raise ValueError('Can only include relationships. "{}" is a "{}"'
                                      .format(field_name, field.__class__.__name__))
-                if not hasattr(field, 'schema') or not field.schema:
-                    raise ValueError('A schema is required to serialize "{}"'.format(field_name))
                 field.include_data = True
             elif isinstance(field, BaseRelationship):
                 field.include_data = False

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -200,6 +200,49 @@ class TestCompoundDocuments:
         for child in data['included']:
             assert child['attributes']['data'] == 'data%s' % child['id']
 
+    def test_include_self_referential_relationship_many_deep(self):
+        class RefSchema(Schema):
+            id = fields.Str()
+            data = fields.Str()
+            children = fields.Relationship(schema='self', type_='refs',
+                                           many=True)
+
+            class Meta:
+                type_ = 'refs'
+
+        obj = {
+            'id': '1',
+            'data': 'data1',
+            'children': [
+                {
+                    'id': '2',
+                    'data': 'data2',
+                    'children': [],
+                },
+                {
+                    'id': '3',
+                    'data': 'data3',
+                    'children': [
+                        {
+                            'id': '4',
+                            'data': 'data4',
+                            'children': []
+                        },
+                        {
+                            'id': '5',
+                            'data': 'data5',
+                            'children': []
+                        }
+                    ]
+                }
+            ]
+        }
+        data = RefSchema(include_data=('children', )).dump(obj).data
+        assert 'included' in data
+        assert len(data['included']) == 4
+        for child in data['included']:
+            assert child['attributes']['data'] == 'data%s' % child['id']
+
 
 def get_error_by_field(errors, field):
     for err in errors['errors']:


### PR DESCRIPTION
When trying to use `many=True` for a `Relationship` field of `schema="self"`, I couldn't get things to serialize properly. This PR fixes that. Additionally, it includes the doc fixes from PR #1, which this supersedes.

Relates to https://github.com/marshmallow-code/marshmallow-jsonapi/pull/40
